### PR TITLE
Explicitly move to Beets 1.4.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER Gavin Brooks <gavin@brks.io>
 
-ENV VERSION v1.4.4
+ENV VERSION 1.4.6
 
 # This points beets towards our external volume mount, for config and db files
 ENV BEETSDIR /config
@@ -10,7 +10,7 @@ RUN adduser -D -u 1000 beets users
 
 RUN apk add --update python py-pip && \
     pip install -U pip && \
-    pip install -U beets requests pylast
+    pip install -U beets==$VERSION requests pylast
 
 # Script that user can run to populate a config file
 ADD src/init_config.sh /usr/local/bin/init_config.sh


### PR DESCRIPTION
Hi Gavin, 

I really appreciate your clean Dockerfile implementation for Beets.  This pull request will bring us up to version 1.4.6, which contains the hugely exciting ability to merge albums (ok, maybe not that exciting but it's been on the todo list for a long time).  Also, I added a line to explicitly fix the pip install of beets to the VERSION environment variable.  This could save a build from Dockerfile unintentionally getting a version of Beets that's inconsistent with the stated VERSION.

Thanks!